### PR TITLE
Allow video selection and mock peer node

### DIFF
--- a/components/Index.tsx
+++ b/components/Index.tsx
@@ -14,18 +14,21 @@ const Index = () => {
   const [activeTab, setActiveTab] = useState('Market');
   // mock data for now
   const [File, setFile] = useState<MarketFile[]>([]);
+  const [ActiveHash, setActiveHash] = useState<string>();
   const [animateIcon, setAnimateIcon] = useState(false);
 
   const renderScreen = () => {
     switch (activeTab) {
       case 'Viewer':
-        return <ViewerTab />;
+        return <ViewerTab videoHash={ActiveHash} />;
       case 'Market':
         return (
           <MarketTab
             setAnimateIcon={setAnimateIcon}
             setFile={setFile}
+            setActiveHash={setActiveHash}
             MyFile={File}
+            setActiveTab={setActiveTab}
           />
         );
       case 'Stats':
@@ -77,7 +80,7 @@ const Index = () => {
       <View style={styles.content}>{renderScreen()}</View>
       <View style={styles.bottomBar}>
         <TouchableOpacity
-          onPress={() => setActiveTab('Viewer')}
+          onPress={() => setActiveTab('Transaction')}
           style={styles.tab}
         >
           <AntDesign name="file1" size={24} color="black" />

--- a/components/Tabs/MarketTab/MarketTab.tsx
+++ b/components/Tabs/MarketTab/MarketTab.tsx
@@ -12,10 +12,13 @@ import {
 } from 'react-native';
 import {marketData} from 'components/api/MockMarketData';
 import {MarketFile} from 'components/api/types';
+import Icon from 'react-native-vector-icons/FontAwesome';
 
 type Props = {
   setAnimateIcon: React.Dispatch<React.SetStateAction<boolean>>;
   setFile: React.Dispatch<React.SetStateAction<MarketFile[]>>;
+  setActiveHash: React.Dispatch<React.SetStateAction<string>>;
+  setActiveTab: React.Dispatch<React.SetStateAction<string>>;
   MyFile: MarketFile[];
 };
 
@@ -26,7 +29,7 @@ const MarketTab = (props: Props) => {
   const [selectedFile, setSelectedFile] = useState<MarketFile | null>(null);
   const [showConfirmation, setShowConfirmation] = useState<boolean>(false);
   const [showAlreadyBrought, setShowAlreadyBrought] = useState<boolean>(false);
-  const {setAnimateIcon, setFile, MyFile} = props;
+  const {setAnimateIcon, setFile, setActiveHash, setActiveTab, MyFile} = props;
 
   const handleSearchInputChange = (query: string) => {
     setSearchQuery(query);
@@ -98,11 +101,16 @@ const MarketTab = (props: Props) => {
     </TouchableOpacity>
   );
 
-  const handleConfirmBuy = () => {
+  const handleConfirmBuy = (view : boolean) => {
     MyFile.push(selectedFile);
     setFile(MyFile)
     setAnimateIcon(true);
     setShowConfirmation(false);
+
+    if(view){
+      setActiveHash(selectedFile.fileHash);
+      setActiveTab("Viewer");
+    }
   };
 
   const handleCancelBuy = () => {
@@ -139,8 +147,16 @@ const MarketTab = (props: Props) => {
             <Text style={styles.modalText}>
               Are you sure you want to buy this file?
             </Text>
-            <Button title="Confirm" onPress={handleConfirmBuy} />
-            <Button title="Cancel" onPress={handleCancelBuy} />
+            <TouchableOpacity
+              style={styles.closeButton}
+              onPress={() => setShowConfirmation(false)}
+            >
+              <Icon name="close" size={25} color="black" />
+            </TouchableOpacity>
+            <View style={styles.buttonsContainer}>
+              <Button title="View" onPress={() => handleConfirmBuy(true)} />
+              <Button title="Download" onPress={() => handleConfirmBuy(false)} />
+            </View>
           </View>
         </View>
       </Modal>
@@ -214,18 +230,30 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)', // semi-transparent black background
   },
   modalContent: {
-    backgroundColor: '#fff',
+    backgroundColor: 'white',
     padding: 20,
     borderRadius: 10,
-    alignItems: 'center',
+    width: '80%', // Adjust the width as per your requirement
   },
   modalText: {
-    fontSize: 18,
+    fontSize: 16,
     marginBottom: 20,
-    textAlign: 'center',
+  },
+  buttonsContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  closeButton: {
+    position: 'absolute',
+    top: 10,
+    right: 10,
+    width:25,
+    height:25,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
 });
 

--- a/components/Tabs/ViewerTab.tsx
+++ b/components/Tabs/ViewerTab.tsx
@@ -2,9 +2,15 @@ import { Text, View, StyleSheet, Dimensions } from 'react-native';
 import React, { useRef, useState } from 'react';
 import { ResizeMode, Video } from 'expo-av';
 
-const ViewerTab = () => {
+type Props = {
+  videoHash : string
+}
+
+const ViewerTab = (props: Props) => {
   const video = useRef(null);
   const [status, setStatus] = useState({});
+
+  const {videoHash} = props
 
   return (
     <View style={styles.container}>
@@ -12,11 +18,12 @@ const ViewerTab = () => {
         ref={video}
         style={styles.video}
         source={{
-          uri: 'https://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4',
+          uri: 'http://localhost:5000/video?hash=' + videoHash,
         }}
         useNativeControls
         resizeMode={ResizeMode.CONTAIN}
         onPlaybackStatusUpdate={status => setStatus(() => status)}
+        shouldPlay={true}
       />
     </View>
   );

--- a/components/api/MockMarketData.tsx
+++ b/components/api/MockMarketData.tsx
@@ -9,6 +9,11 @@ export const marketData = [
     name: 'The Dark Knight',
     size: 1800, // 1.8 GB
   },
+  {
+    fileHash: 'video.mp4',
+    name: 'Spongebob',
+    size: 100, // 0.1 GB
+  },
   // {
   //   fileHash: 'QmUx6Qe3c56JpV93HZqo51FUsXbt7YvLpcRUPFDK5ewFLd',
   //   name: 'Inception',

--- a/mock-peer/server.py
+++ b/mock-peer/server.py
@@ -1,0 +1,22 @@
+from flask import Flask, send_file, Response, request
+
+app = Flask(__name__)
+
+@app.route('/video')
+def stream_video():
+    hash_value = request.args.get('hash')
+    
+    video_path = hash_value  # Path to your video file
+    chunk_size = 8 * 1024 * 1024  # 8MB chunks
+    return Response(stream_with_chunks(video_path, chunk_size), mimetype='video/mp4')
+
+def stream_with_chunks(path, chunk_size):
+    with open(path, 'rb') as f:
+        while True:
+            chunk = f.read(chunk_size)
+            if not chunk:
+                break
+            yield chunk
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
NOTE: To run the mock peer node, you must install flask: "pip install Flask"

Changes:
- Viewer tab no longer selectable (for now links to transactions)
- When buying a file there is now an option to view
- As of now the only working file is "Spongebob"
